### PR TITLE
Agent list made dynamic

### DIFF
--- a/run.py
+++ b/run.py
@@ -152,29 +152,17 @@ def call():
 
 @app.route("/agent_list", methods=['GET', 'POST'])
 def generate_agent_list_view():
-    #create an array of workers and share that with the template so that workers can be queried on the client side
+    # Create arrays of workers and share that with the template so that workers can be queried on the client side
 
-    workers = client.taskrouter.workspaces(workspace_sid).workers.list()
-    worker_list = []
-    worker_chat = []
+    # All workers can do voice
+    all_workers = client.taskrouter.workspaces(workspace_sid).workers.list()
 
+    # Only some workers can do chat
     expression = "skills HAS 'chat'"
-
     chat_workers = client.taskrouter.workspaces(workspace_sid) \
         .workers.list(target_workers_expression=expression)
 
-    for c_worker in chat_workers:
-        worker_chat.append(c_worker.sid)
-        worker_chat.append(c_worker.friendly_name)
-
-    for worker in workers:
-        worker_list.append(worker.sid)
-        worker_list.append(worker.friendly_name)
-
-    for cheese in worker_chat:
-        print(cheese)
-
-    return render_template('agent_list.html', workers=worker_list, chatworkers = chat_workers)
+    return render_template('agent_list.html', voice_workers=all_workers, chat_workers=chat_workers)
 
 
 @app.route("/agents", methods=['GET'])

--- a/templates/agent_list.html
+++ b/templates/agent_list.html
@@ -7,26 +7,17 @@
 
 </head>
 <body>
-<div  id="workers">
+<div id="workers">
     <h2>A selection of voice workers</h2>
-
-      <a href="/agents?WorkerSid={{ workers[0] }}">{{ workers[1] }}</a><br />
-      <a href="/agents?WorkerSid={{ workers[2] }}">{{ workers[3] }}</a><br />
-      <a href="/agents?WorkerSid={{ workers[4] }}">{{ workers[5] }}</a><br />
-
-      <a href="/agents?WorkerSid={{ workers[6] }}">{{ workers[7] }}</a><br />
-      <a href="/agents?WorkerSid={{ workers[8] }}">{{ workers[9] }}</a><br />
-
-      <a href="/agents?WorkerSid={{ workers[10] }}">{{ workers[11] }}</a><br />
-
-      <a href="/agents?WorkerSid={{ workers[12] }}">{{ workers[13] }}</a><br />
-      <a href="/agents?WorkerSid={{ workers[14] }}">{{ workers[15] }}</a><br />
+    {% for worker in voice_workers %}
+      <a href="/agents?WorkerSid={{ worker.sid }}">{{ worker.friendly_name }}</a><br />
+    {% endfor %}
 </div>
-<div  id="workers">
+<div id="workers">
     <h2>A selection of chat workers</h2>
-
-      <a href="/agent_chat?WorkerSid=WK7d2e2a04bb9afb289cec096e07221409">Francisco</a><br />
-      <a href="/agent_chat?WorkerSid=WK98e7ffd8b93c1942314f1f3223ecab55">Bob</a><br />
+    {% for c_worker in chat_workers %}
+      <a href="/agent_chat?WorkerSid={{ c_worker.sid }}">{{ c_worker.friendly_name }}</a><br />
+    {% endfor %}
 </div>
 </body>
 </html>


### PR DESCRIPTION
The list of agents was populated statically, changed it to dynamic.

For chat I based it on 'skills':'chat', however we may want to base this on 'chat' Task Channel being available to avoid double-provisioning and issues associated with that (i.e. Chat capacity set, but no 'chat' skill configured). What do you think? 

We could then also do the same for Voice (only provision agents that have Task Channel 'voice' available).